### PR TITLE
adopt length-delimited QMux Records

### DIFF
--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -85,10 +85,9 @@ QUIC}}.
 QMux can be used on any transport that provides a bi-directional, byte-oriented
 stream that is ordered and reliable; for details, see {{transport-properties}}.
 
-QMux uses a two-layer encoding; see {{records}}.
-
-The frames are not encrypted. It is the task of the transport (e.g., TLS) to
-provide confidentially and integrity.
+QMux transfers one or more QUIC frames within a QMux record; see {{records}}.
+Neither QUIC frames nor QMux records are encrypted in this protocol; it is the
+task of the transport (e.g., TLS) to provide confidentiality and integrity.
 
 QUIC packet headers are not used.
 

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -148,7 +148,7 @@ QMux Records contain the following fields:
 
 Size:
 
-: A variable-length integer specifying the length in bytes of the Frames field.
+: A variable-length integer specifying the length in bytes of the Frames field. Note that this length does not include the Size field itself.
 
 Frames:
 

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -226,11 +226,10 @@ byte stream transport, requires STREAM frames for each QUIC stream to be sent
 in order: i.e., for each QUIC stream being sent, senders MUST send stream
 payload in order.
 
-This change from QUIC version 1 eliminates the need for implementations to
-buffer and reassemble the stream payload. As a result, the payload being
-received can be directly passed to the application as it is read from the
-transport. This efficiency is due to the underlying transport's guarantee of
-in-order delivery.
+This change eliminates the need for implementations to buffer and reassemble
+the stream payload. As a result, the payload being received can be directly
+passed to the application as it is read from the transport. This efficiency is
+due to the underlying transport's guarantee of in-order delivery.
 
 When receiving a STREAM frame that carries a payload not immediately following
 the payload of the previous STREAM frame for the same Stream ID, receivers MUST

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -352,7 +352,7 @@ MUST ignore them unless they are specified to be usable on QMux.
 ## max_record_size Transport Parameter {#max_record_size}
 
 The `max_record_size` Transport Parameter (0xTBD) is a variable-length integer
-specifying the maximum size of the Frames field of a QMux Record that the peer
+specifying the maximum value of the Size field of a QMux Record that the peer
 can send, in the unit of bytes.
 
 The initial value of the `max_record_size` Transport Parameter is 16382.

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -223,7 +223,7 @@ In QUIC version 1, the order in which STREAM frames are sent or received is not
 guaranteed, because packets can be lost and frames can be retransmitted in
 different packets. In contrast, QMux, which runs over an ordered and reliable
 byte stream transport, requires STREAM frames for each QUIC stream to be sent
-in order: i.e., for each QUIC stream being sent, senders MUST send stream
+in order: i.e., for each QUIC stream being sent, senders MUST send the stream
 payload in order.
 
 This change eliminates the need for implementations to buffer and reassemble

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -85,7 +85,7 @@ QUIC}}.
 QMux can be used on any transport that provides a bi-directional, byte-oriented
 stream that is ordered and reliable; for details, see {{transport-properties}}.
 
-QUIC frames are sent directly on top of the transport.
+QMux uses a two-layer encoding; see {{records}}.
 
 The frames are not encrypted. It is the task of the transport (e.g., TLS) to
 provide confidentially and integrity.
@@ -132,6 +132,47 @@ Confidentiality and integrity protection are deemed unnecessary in environments
 where the operating system is trusted.
 
 
+## QMux Records {#records}
+
+QMux Records are formatted as shown in {{fig-qmux-record}}.
+
+~~~
+QMux Record {
+  Size (i),
+  Frames (..),
+}
+~~~
+{: #fig-qmux-record title="QMux Record Format"}
+
+QMux Records contain the following fields:
+
+Size:
+
+: A variable-length integer specifying the length in bytes of the Frames field.
+
+Frames:
+
+: A byte sequence that contains one or more QUIC frames.
+
+Each QMux Record is self-delimiting. On a byte stream transport, endpoints
+parse QMux Records by first parsing Size and then reading exactly that many
+bytes as Frames. The bytes in Frames are interpreted as a contiguous series of
+QUIC frames encoded using QUIC version 1 framing.
+
+As with QUIC packet payloads ({{Section 12.4 of QUIC}}), frames are complete
+units: a frame MUST fit entirely within a single QMux Record and MUST NOT span
+multiple QMux Records.
+
+Senders can choose record boundaries freely, subject to the `max_record_size`
+Transport Parameter ({{max_record_size}}). Receivers process frames within each
+record, using the record boundary as the payload boundary for frames that omit
+an explicit length.
+
+If the end of the Frames field is not aligned to a frame boundary (that is, if
+the final frame in the record is truncated), the receiver MUST close the
+connection with an error of type FRAME_ENCODING_ERROR.
+
+
 # QUIC Frames
 
 In QMux, the following QUIC frames can be used, as if they were sent or received
@@ -176,39 +217,24 @@ Endpoints MUST NOT send prohibited frames. If an endpoint receives one it MUST
 close the connection with an error of type FRAME_ENCODING_ERROR.
 
 
-## STREAM Frames {#stream-frames}
+## Ordering of STREAM Frames {#stream-frames}
 
-While the frame format remains unchanged, there are two differences in the
-handling of STREAM frames between QUIC version 1 and QMux.
-
-
-### STREAM Frames without the Length Field
-
-In QMux, when a STREAM frame that omits the Length field is used, the size of
-that STREAM frame is determined by the maximum frame size, as regulated by the
-`max_frame_size` Transport Parameter ({{max_frame_size}}).
-
-This behavior contrasts with that of QUIC version 1, where the absence of the
-Length field implies that the STREAM frame extends to the end of the QUIC packet
-payload.
-
-This variation arises due to the characteristics of the underlying transports of
-QMux, which may not have, or provide visibility into, the packet boundaries.
-
-
-### Ordering of STREAM frames
-
-For each stream being sent, senders MUST send stream payload in order.
-
-When receiving a STREAM frame that carries a payload not immediately following
-the payload of the previous STREAM frame for the same Stream ID, receivers MUST
-close connection with an error of type PROTOCOL_VIOLATION_ERROR.
+In QUIC version 1, the order in which STREAM frames are sent or received is not
+guaranteed, because packets can be lost and frames can be retransmitted in
+different packets. In contrast, QMux, which runs over an ordered and reliable
+byte stream transport, requires STREAM frames for each QUIC stream to be sent
+in order: i.e., for each QUIC stream being sent, senders MUST send stream
+payload in order.
 
 This change from QUIC version 1 eliminates the need for implementations to
 buffer and reassemble the stream payload. As a result, the payload being
 received can be directly passed to the application as it is read from the
 transport. This efficiency is due to the underlying transport's guarantee of
 in-order delivery.
+
+When receiving a STREAM frame that carries a payload not immediately following
+the payload of the previous STREAM frame for the same Stream ID, receivers MUST
+close the connection with an error of type PROTOCOL_VIOLATION_ERROR.
 
 These changes do not impact the senders' capability to interleave STREAM frames
 from multiple streams.
@@ -325,23 +351,27 @@ When receiving Transport Parameters not defined in QUIC version 1, receivers
 MUST ignore them unless they are specified to be usable on QMux.
 
 
-## max_frame_size Transport Parameter {#max_frame_size}
+## max_record_size Transport Parameter {#max_record_size}
 
-The `max_frame_size` Transport Parameter (0xTBD) is a variable-length integer
-specifying the maximum size of the QUIC frame that the peer can send, in the
-unit of bytes.
+The `max_record_size` Transport Parameter (0xTBD) is a variable-length integer
+specifying the maximum size of the Frames field of a QMux Record that the peer
+can send, in the unit of bytes.
 
-The initial value of the `max_frame_size` Transport Parameter is 16384.
+The initial value of the `max_record_size` Transport Parameter is 16382.
+This value allows a sender to construct a 16KB QMux Record by using a 2-byte
+Size field and a 16382-byte Frames field, aligning with the default capacity of
+a full-sized TLS record.
 
-By sending the Transport Parameter, the maximum frame size can only be
+By sending the Transport Parameter, the maximum record size can only be
 increased. When receiving a value below the initial value, receivers MUST close
 the connection with an error of type TRANSPORT_PARAMETER_ERROR.
 
-Endpoints MUST NOT send QUIC frames that exceed the maximum declared by the
-peer.
+Endpoints MUST NOT send QMux Records with a Frames field that exceeds the
+maximum declared by the peer.
 
-When receiving QUIC frames that exceed the declared maximum, receivers MUST
-close the connection with an error of type FRAME_ENCODING_ERROR.
+When receiving a QMux Record with a Frames field that exceeds the declared
+maximum, receivers MUST close the connection with an error of type
+FRAME_ENCODING_ERROR.
 
 
 # Closing the Connection
@@ -381,14 +411,8 @@ This specification defines the mapping of the Unreliable Datagram Extension.
 ## Unreliable Datagram Extension
 
 The use of the Unreliable Datagram Extension {{!QUIC_DATAGRAM=RFC9221}} is
-permitted, with one modification:
-
-Similar to STREAM frames, when employing DATAGRAM frames of type 0x30 (i.e.,
-DATAGRAM frames without the Length field), their size is determined by the
-`max_frame_size` Transport Parameter ({{max_frame_size}}).
-
-Apart from this, the encoding and semantics of the Unreliable Datagram Extension
-remain unchanged. The use of the extension is negotiated via the Transport
+permitted. The encoding and semantics of the Unreliable Datagram Extension
+remain unchanged, and the use of the extension is negotiated via Transport
 Parameters.
 
 As discussed in {{Section 5 of QUIC_DATAGRAM}}, senders can drop DATAGRAM frames


### PR DESCRIPTION
This updates the draft to address #21 by adopting a two-layer encoding with a length-delimited QMux Record carrying QUIC v1 frames.

It defines QMux Record format and parsing rules, updates STREAM/DATAGRAM text for record boundaries, and renames the transport parameter to max_record_size (default 16382).

Closes #21.