### PR TITLE
add forward-progress requirements for flow control

### DIFF
--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -355,9 +355,9 @@ reads on any single QUIC stream, as doing so can prevent processing of frames
 required for connection progress.
 
 Continuing to read does not imply unbounded buffering of STREAM data, as the
-amount of stream data a peer can send is limited by QUIC flow control. For
-DATAGRAM frames, endpoints MAY drop received datagrams when they cannot be
-promptly delivered to the application.
+amount of stream data a peer can send is limited by flow control
+({{Section 4 of QUIC}}). For DATAGRAM frames, endpoints MAY drop received
+datagrams when they cannot be promptly delivered to the application.
 
 
 # Closing the Connection


### PR DESCRIPTION
Add a dedicated Forward Progress and Flow Control section with normative requirements to keep reading from the underlying transport and avoid coupling transport reads to a single stream's application reads.

Clarify bounded buffering and DATAGRAM drop behavior, and add a Security Considerations reference to deadlock/resource-exhaustion risk.

Closes #9.