### PR TITLE
QX_TRANSPORT_PARAMETERS is sent once and only as the 1st frame

### DIFF
--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -250,9 +250,11 @@ peer's Transport Parameters before sending its own, as Transport Parameters are
 a unilateral declaration of an endpoint's capabilities
 ({{Section 7.4 of QUIC}}).
 
-If the first frame being received by an endpoint is not a
-QX_TRANSPORT_PARAMETERS frame, the endpoint MUST close the connection with an
-error of type TRANSPORT_PARAMETER_ERROR.
+The QX_TRANSPORT_PARAMETERS frame MUST only be sent as the first frame. If the
+first frame being received by an endpoint is not a QX_TRANSPORT_PARAMETERS
+frame, or if a QX_TRANSPORT_PARAMETERS frame is received other than as the first
+frame, the endpoint MUST close the connection with an error of type
+TRANSPORT_PARAMETER_ERROR.
 
 The frame type (0x3f5153300d0a0d0a; "\xffQMX\r\n\r\n" on wire) has been chosen
 so that it can be used to disambiguate QMux from HTTP/1.1 {{?HTTP1=RFC9112}} and


### PR DESCRIPTION
Closes #36.