### PR TITLE
`max_record_size` is specified only for QMux

### DIFF
--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -409,7 +409,8 @@ FRAME_ENCODING_ERROR.
 
 This document does not specify the use of the `max_record_size` transport
 parameter with QUIC version 1. Absent such a specification, QUIC version 1
-endpoints are required to ignore the `max_record_size` transport parameter.
+endpoints are required to ignore the `max_record_size` transport parameter
+({{Section 7.4.2 of QUIC}}).
 
 
 # Forward Progress and Flow Control {#forward-progress-flow-control}

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -407,6 +407,10 @@ When receiving a QMux Record with a Frames field that exceeds the declared
 maximum, receivers MUST close the connection with an error of type
 FRAME_ENCODING_ERROR.
 
+This document does not specify the use of the `max_record_size` transport
+parameter with QUIC version 1. Absent such a specification, QUIC version 1
+endpoints are required to ignore the `max_record_size` transport parameter.
+
 
 # Forward Progress and Flow Control {#forward-progress-flow-control}
 

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -408,9 +408,9 @@ maximum, receivers MUST close the connection with an error of type
 FRAME_ENCODING_ERROR.
 
 This document does not specify the use of the `max_record_size` transport
-parameter with QUIC version 1. Absent such a specification, QUIC version 1
-endpoints are required to ignore the `max_record_size` transport parameter
-({{Section 7.4.2 of QUIC}}).
+parameter with QUIC version 1. Absent such a specification, the
+`max_record_size` transport parameter is ignored by QUIC version 1 endpoints as
+an unknown transport parameter, as defined in ({{Section 7.4.2 of QUIC}}).
 
 
 # Forward Progress and Flow Control {#forward-progress-flow-control}


### PR DESCRIPTION
Clarify that the use of `max_record_size` TP is unspecified for QUIC version 1. The net effect is that QUIC version 1 endpoints will ignore the `max_record_size` TP on QUIC version 1, even if the same QUIC stack understands QMux.

Closes #47.