### PR TITLE
to indicate misuse of QX_TRANSPORT_PARAMETERS frame, use PROTOCOL_VIOLATION 

### DIFF
--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -311,7 +311,7 @@ The QX_TRANSPORT_PARAMETERS frame MUST only be sent as the first frame. If the
 first frame being received by an endpoint is not a QX_TRANSPORT_PARAMETERS
 frame, or if a QX_TRANSPORT_PARAMETERS frame is received other than as the first
 frame, the endpoint MUST close the connection with an error of type
-TRANSPORT_PARAMETER_ERROR.
+PROTOCOL_VIOLATION.
 
 The frame type (0x3f5153300d0a0d0a; "\xffQMX\r\n\r\n" on wire) has been chosen
 so that it can be used to disambiguate QMux from HTTP/1.1 {{?HTTP1=RFC9112}} and

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -254,7 +254,7 @@ due to the underlying transport's guarantee of in-order delivery.
 
 When receiving a STREAM frame that carries a payload not immediately following
 the payload of the previous STREAM frame for the same Stream ID, receivers MUST
-close the connection with an error of type PROTOCOL_VIOLATION_ERROR.
+close the connection with an error of type PROTOCOL_VIOLATION.
 
 These changes do not impact the senders' capability to interleave STREAM frames
 from multiple streams.


### PR DESCRIPTION
The established convention in QUIC version 1 is to use the PROTOCOL_VIOLATION error code when an endpoint receives a particular type of frame when it should not.

QMux should do the same; i.e., when an endpoint receives a QX_TRANSPORT_PARAMETERS frame when it should not, the correct error code to use is PROTOCOL_VIOLATION, not TRANSPORT_PARAMETER_ERROR.

Closes #49.