### PR TITLE
clarify TPs defined outside of RFC 9000 are not prohibited

### DIFF
--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -375,14 +375,31 @@ following transport parameters is allowed:
 
 The definitions of these transport parameters are unchanged.
 
-Use of other transport parameters defined in {{QUIC}} is prohibited. When an
-endpoint receives one of the prohibited transport parameters, the endpoint MUST
-close the connection with an error of type TRANSPORT_PARAMETER_ERROR.
+Use of all other transport parameters defined in {{Section 18.2 of QUIC}},
+namely the following, is prohibited:
+
+* original_destination_connection_id
+* stateless_reset_token
+* max_udp_payload_size
+* ack_delay_exponent
+* max_ack_delay
+* disable_active_migration
+* preferred_address
+* active_connection_id_limit
+* initial_source_connection_id
+* retry_source_connection_id
+
+When an endpoint receives one of the prohibited transport parameters, the
+endpoint MUST close the connection with an error of type
+TRANSPORT_PARAMETER_ERROR.
 
 Endpoints MUST NOT send transport parameters defined outside of {{QUIC}} unless
 they are specified to be usable with QMux. Similarly, endpoints MUST ignore
 transport parameters defined outside of {{QUIC}} unless they are specified to be
 usable with QMux; see {{extensions}}.
+
+As in QUIC, reserved transport parameters can be used to exercise the peer's
+ability to ignore unknown transport parameters ({{Section 7.4.2 of QUIC}}).
 
 
 ## max_record_size Transport Parameter {#max_record_size}

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -373,7 +373,7 @@ following transport parameters is allowed:
 * initial_max_streams_bidi
 * initial_max_streams_uni
 
-The definition of these transport parameters are unchanged.
+The definitions of these transport parameters are unchanged.
 
 Use of other transport parameters defined in {{QUIC}} is prohibited. When an
 endpoint receives one of the prohibited transport parameters, the endpoint MUST

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -398,8 +398,10 @@ they are specified to be usable with QMux. Similarly, endpoints MUST ignore
 transport parameters defined outside of {{QUIC}} unless they are specified to be
 usable with QMux; see {{extensions}}.
 
-As in QUIC, reserved transport parameters can be used to exercise the peer's
-ability to ignore unknown transport parameters ({{Section 7.4.2 of QUIC}}).
+QUIC defines a reserved range of transport parameters for the purpose of
+exercising a peer's ability to ignore unknown transport parameters
+({{Section 7.4.2 of QUIC}}. The use of these transport parameters in QMux for
+the same purpose is allowed.
 
 
 ## max_record_size Transport Parameter {#max_record_size}

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -362,7 +362,8 @@ new transport parameter specific to QMux is defined.
 
 ## Permitted and Forbidden Transport Parameters {#permitted-tps}
 
-In QMux, use of the following transport parameters is allowed.
+Among the transport parameters defined in {{Section 18.2 of QUIC}}, use of the
+following transport parameters is allowed:
 
 * max_idle_timeout
 * initial_max_data
@@ -374,15 +375,14 @@ In QMux, use of the following transport parameters is allowed.
 
 The definition of these transport parameters are unchanged.
 
-Use of other transport parameters defined in QUIC version 1 is prohibited. When
-an endpoint receives one of the prohibited transport parameters, the endpoint
-MUST close the connection with an error of type TRANSPORT_PARAMETER_ERROR.
+Use of other transport parameters defined in {{QUIC}} is prohibited. When an
+endpoint receives one of the prohibited transport parameters, the endpoint MUST
+close the connection with an error of type TRANSPORT_PARAMETER_ERROR.
 
-Endpoints MUST NOT send transport parameters that extend QUIC version 1, unless
-they are specified to be compatible with QMux.
-
-When receiving transport parameters not defined in QUIC version 1, receivers
-MUST ignore them unless they are specified to be usable on QMux.
+Endpoints MUST NOT send transport parameters defined outside of {{QUIC}} unless
+they are specified to be usable with QMux. Similarly, endpoints MUST ignore
+transport parameters defined outside of {{QUIC}} unless they are specified to be
+usable with QMux; see {{extensions}}.
 
 
 ## max_record_size Transport Parameter {#max_record_size}

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -393,15 +393,15 @@ When an endpoint receives one of the prohibited transport parameters, the
 endpoint MUST close the connection with an error of type
 TRANSPORT_PARAMETER_ERROR.
 
-Endpoints MUST NOT send transport parameters defined outside of {{QUIC}} unless
-they are specified to be usable with QMux. Similarly, endpoints MUST ignore
-transport parameters defined outside of {{QUIC}} unless they are specified to be
-usable with QMux; see {{extensions}}.
-
 QUIC defines a reserved range of transport parameters for the purpose of
 exercising a peer's ability to ignore unknown transport parameters
 ({{Section 7.4.2 of QUIC}}). The use of these transport parameters in QMux for
 the same purpose is allowed.
+
+Endpoints MUST NOT send transport parameters defined outside of {{QUIC}} unless
+they are specified to be usable with QMux. Similarly, endpoints MUST ignore
+transport parameters defined outside of {{QUIC}} unless they are specified to be
+usable with QMux; see {{extensions}}.
 
 
 ## max_record_size Transport Parameter {#max_record_size}

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -375,7 +375,7 @@ following transport parameters is allowed:
 
 The definitions of these transport parameters are unchanged.
 
-Use of all other transport parameters defined in {{Section 18.2 of QUIC}} 
+Use of all other transport parameters defined in {{Section 18.2 of QUIC}}
 is prohibited, namely the following:
 
 * original_destination_connection_id

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -400,7 +400,7 @@ usable with QMux; see {{extensions}}.
 
 QUIC defines a reserved range of transport parameters for the purpose of
 exercising a peer's ability to ignore unknown transport parameters
-({{Section 7.4.2 of QUIC}}. The use of these transport parameters in QMux for
+({{Section 7.4.2 of QUIC}}). The use of these transport parameters in QMux for
 the same purpose is allowed.
 
 

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -375,8 +375,8 @@ following transport parameters is allowed:
 
 The definitions of these transport parameters are unchanged.
 
-Use of all other transport parameters defined in {{Section 18.2 of QUIC}},
-namely the following, is prohibited:
+Use of all other transport parameters defined in {{Section 18.2 of QUIC}} 
+is prohibited, namely the following:
 
 * original_destination_connection_id
 * stateless_reset_token


### PR DESCRIPTION
Addresses the concern raised in #46.

With the change, the subsection now groups TPs into two groups: those defined in RFC 9000 (specifically, section 18.2) and those defined _outside of_ RFC 9000. Reference to the extensions section is added too.

Closes #46.