### PR TITLE
expand connection close

### DIFF
--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -452,8 +452,10 @@ acknowledgments.
 When no other traffic is available, QX_PING frames can be used to elicit a peer
 response and keep both the QMux connection and the underlying transport active.
 
-When an endpoint reaches the idle timeout, the connection is closed and the
-underlying transport is closed immediately.
+When an endpoint reaches the idle timeout, they can immediately
+close the underlying transport
+or abandon it without transmitting any signal
+at their discretion.
 
 
 ## Underlying Transport Termination

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -452,10 +452,9 @@ acknowledgments.
 When no other traffic is available, QX_PING frames can be used to elicit a peer
 response and keep both the QMux connection and the underlying transport active.
 
-When an endpoint reaches the idle timeout, they can immediately
-close the underlying transport
-or abandon it without transmitting any signal
-at their discretion.
+When an endpoint reaches the idle timeout, they can immediately close the
+underlying transport or abandon it without transmitting any signal at their
+discretion.
 
 
 ## Underlying Transport Termination

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -424,20 +424,42 @@ amount of stream data a peer can send is limited by flow control
 datagrams when they cannot be promptly delivered to the application.
 
 
-# Closing the Connection
+# Connection Termination
 
-As is with QUIC version 1, a connection can be closed either by a
-CONNECTION_CLOSE frame or by an idle timeout.
+A QMux connection can be terminated by a CONNECTION_CLOSE frame, by an idle
+timeout, or by termination of the underlying transport.
 
-Unlike QUIC version 1, idle timeout handling does not rely on ACK frames.
-Endpoints reset the idle timer when sending or receiving QMux frames. When no
-other traffic is available, QX_PING frames can be used to elicit a peer
-response and keep the connection active.
 
-Unlike QUIC version 1, there is no draining period; once an endpoint sends or
-receives the CONNECTION_CLOSE frame or reaches the idle timeout, all the
-resources allocated for the Service are freed and the underlying transport is
-closed immediately.
+## Immediate Close
+
+As in QUIC version 1, an endpoint closes the QMux connection by sending a
+CONNECTION_CLOSE frame. Unlike QUIC version 1, there is no draining period; once
+an endpoint sends or receives the CONNECTION_CLOSE frame, all resources
+allocated for the connection are freed and the underlying transport is closed
+immediately.
+
+
+## Idle Timeout
+
+As in QUIC version 1, endpoints can negotiate an idle timeout using the
+max_idle_timeout transport parameter.
+
+Endpoints reset the idle timer when sending or receiving a QMux record. Activity
+on the underlying transport, such as TCP keepalives, does not reset the idle
+timer. Unlike QUIC version 1, idle timeout handling does not rely on
+acknowledgments.
+
+When no other traffic is available, QX_PING frames can be used to elicit a peer
+response and keep both the QMux connection and the underlying transport active.
+
+When an endpoint reaches the idle timeout, the connection is closed and the
+underlying transport is closed immediately.
+
+
+## Underlying Transport Termination
+
+When the underlying transport closes or becomes unavailable (e.g., due to a TCP
+reset or a TLS fatal alert), the QMux connection is also terminated.
 
 
 # Using TLS
@@ -589,9 +611,30 @@ throughput.
 
 # Security Considerations
 
+QMux inherits many of the security properties and considerations laid out in
+{{Section 21 of QUIC}}. This section describes considerations specific to QMux.
+
+
+## Forward Progress
+
 Failure to follow the forward-progress requirements in
 {{forward-progress-flow-control}} can lead to deadlock and can be exploited for
 resource-exhaustion attacks.
+
+
+## Denial of Service
+
+As in QUIC ({{Section 21.9 of QUIC}}), valid QMux frames can be used to keep a
+connection alive, to consume processing resources disproportionate to useful
+progress, or to force an endpoint to generate responses. For example, sending
+large numbers of small records, PADDING frames, tiny flow control increments, or
+QX_PING frames can be used for such purposes. Implementations SHOULD monitor for
+such traffic patterns and MAY treat suspicious activity as a connection error of
+type PROTOCOL_VIOLATION.
+
+Unlike QUIC, where each packet is a self-contained unit, QMux records can arrive
+incrementally over the underlying byte stream. Implementations need to consider
+resources held for partially received records.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -454,10 +454,10 @@ When the idle timeout expires, an endpoint gracefully shuts down its sending
 side of the underlying transport, without sending any frames.
 
 Separately, as in QUIC version 1, an endpoint can initiate closing of a QMux
-connection by sending a CONNECTION_CLOSE frame and then gracefully shuts down
+connection by sending a CONNECTION_CLOSE frame and then gracefully shutting down
 its sending side of the underlying transport.
 
-In either case, once shutting down the sending side, the endpoint SHOULD wait
+In either case, after shutting down the sending side, the endpoint SHOULD wait
 for the peer to gracefully shut down the peer's sending side. The use of
 graceful shutdown mitigates the risk of undelivered records and frames
 becoming lost due to abrupt termination of the underlying transport. While
@@ -471,7 +471,7 @@ discarding packets received during the draining period
 
 When receiving a CONNECTION_CLOSE frame or observing the peer shut down the
 peer's sending side, the receiving endpoint SHOULD gracefully shut down its
-sending side without sending any frames, or after sending a single
+sending side, either without sending any frames or after sending a single
 CONNECTION_CLOSE frame.
 
 

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -432,20 +432,35 @@ frame, or by observing a reset of the underlying transport.
 
 ## Idle Timeout
 
-As in QUIC version 1, endpoints negotiate an idle timeout using the
-max_idle_timeout transport parameter.
+In QUIC version 1, the idle timer is reset whenever a packet is received and
+processed successfully, including acknowledgment-only packets. It also raises
+the idle timeout using PTO, a value derived from when acknowledgments are
+received. QMux cannot adopt this approach as-is since acknowledgments are not
+processed by QMux stacks; they are processed by the underlying transport
+instead.
 
-Endpoints reset the idle timer each time a QMux record is either completely sent
-or completely received. Activity on the underlying transport, such as TCP
-keepalives, does not reset the idle timer. QMux endpoints do not increase their
-idle timeouts relative to the current Probe Timeout (PTO).
+As a consequence, the idle timeout of QMux is defined as follows:
+
+* As in QUIC version 1, endpoints negotiate an idle timeout using the
+  max_idle_timeout transport parameter.
+* As in QUIC version 1, endpoints reset the idle timer each time a QMux record
+  is completely received.
+* Endpoints also reset the idle timer each time a QMux record is completely
+  sent. This is analogous to QUIC version 1 endpoints resetting the idle timer
+  when an acknowledgment-only packet is received. Since acknowledgments are not
+  directly visible to QMux endpoints, QMux endpoints observe the side effect of
+  acknowledgments: bytes drained from the send buffer, opening up space to send
+  more.
+* Activity on the underlying transport, such as TCP keepalives, does not reset
+  the idle timer.
+* QMux endpoints do not increase their idle timeouts relative to the current
+  Probe Timeout (PTO).
 
 When idle, a QMux connection may also be torn down by the underlying transport
 stack or by intermediaries (e.g., Network Address Translation {{?RFC7857}}),
-independent of the negotiated timeout.
-
-QX_PING frames can be used to elicit a peer response and keep both the QMux
-connection and the underlying transport active.
+independent of the negotiated timeout. QX_PING frames can be used to elicit a
+peer response and keep both the QMux connection and the underlying transport
+active.
 
 
 ## Initiating a Connection Close

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -653,7 +653,7 @@ type PROTOCOL_VIOLATION.
 
 Unlike QUIC, where each packet is a self-contained unit, QMux records can arrive
 incrementally over the underlying byte stream. Implementations need to consider
-resources held for partially received records.
+resources they might use to hold partially received records.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -455,8 +455,8 @@ As a consequence, the idle timeout of QMux is defined as follows:
 * QMux endpoints do not increase their idle timeouts relative to the current
   Probe Timeout (PTO).
 
-While idle, a QMux connection may also be torn down by timers outside of QMux;
-e.g., Network Address Translation {{?RFC7857}}. QX_PING frames can be used to
+While idle, a QMux connection may also be disrupted by inactivity timers outside of QMux; e.g., a 
+Network Address Translator {{?RFC7857}} that discards its mapping. QX_PING frames can be used to
 elicit a peer response, which could keep inactivity timers at lower transport
 layers and intermediaries from causing premature connection termination.
 

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -471,7 +471,8 @@ discarding packets received during the draining period
 
 When receiving a CONNECTION_CLOSE frame or observing the peer shut down the
 peer's sending side, the receiving endpoint SHOULD gracefully shut down its
-sending side, without sending any frames.
+sending side without sending any frames, or after sending a single
+CONNECTION_CLOSE frame.
 
 
 ## Handling Resets

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -446,12 +446,10 @@ As a consequence, the idle timeout of QMux is defined as follows:
 * As in QUIC version 1, endpoints reset the idle timer each time a QMux record
   is completely received.
 * Endpoints also reset the idle timer each time a QMux record is completely
-  sent. This is analogous to QUIC version 1 endpoints resetting the idle timer
-  when an acknowledgment-only packet is received. Since acknowledgments are not
-  directly visible to QMux endpoints, QMux does not reset the idle time on acknowledgements.
-  Instead, endpoints only observe the side effect of
-  acknowledgments: bytes drained from the send buffer, opening up space to send
-  more.
+  sent. Since acknowledgments are not directly visible to QMux endpoints, QMux
+  does not reset the idle timer on acknowledgements. Instead, endpoints observe
+  the side effect of acknowledgments: bytes drained from the send buffer,
+  opening up space to send more.
 * Activity on the underlying transport - such as acknowledgments, TCP keepalives, or TLS key updates - does not reset
   the idle timer.
 * QMux endpoints do not increase their idle timeouts relative to the current

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -435,11 +435,11 @@ frame, or by observing a reset of the underlying transport.
 As in QUIC version 1, endpoints negotiate an idle timeout using the
 max_idle_timeout transport parameter.
 
-Endpoints reset the idle timer when sending or receiving a QMux record. Activity
-on the underlying transport, such as TCP keepalives, does not reset the idle
-timer. Unlike QUIC version 1, idle timeout handling does not rely on
-acknowledgments; QMux endpoints do not increase their idle timeouts relative to
-the current Probe Timeout (PTO).
+Endpoints reset the idle timer each time a QMux record is either completely sent
+or completely received. Activity on the underlying transport, such as TCP
+keepalives, does not reset the idle timer. Unlike QUIC version 1, idle timeout
+handling does not rely on acknowledgments; QMux endpoints do not increase their
+idle timeouts relative to the current Probe Timeout (PTO).
 
 When idle, a QMux connection may also be torn down by the underlying transport
 stack or by intermediaries (e.g., Network Address Translation {{?RFC7857}}),

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -448,10 +448,11 @@ As a consequence, the idle timeout of QMux is defined as follows:
 * Endpoints also reset the idle timer each time a QMux record is completely
   sent. This is analogous to QUIC version 1 endpoints resetting the idle timer
   when an acknowledgment-only packet is received. Since acknowledgments are not
-  directly visible to QMux endpoints, QMux endpoints observe the side effect of
+  directly visible to QMux endpoints, QMux does not reset the idle time on acknowledgements.
+  Instead, endpoints only observe the side effect of
   acknowledgments: bytes drained from the send buffer, opening up space to send
   more.
-* Activity on the underlying transport, such as TCP keepalives, does not reset
+* Activity on the underlying transport - such as acknowledgments, TCP keepalives, or TLS key updates - does not reset
   the idle timer.
 * QMux endpoints do not increase their idle timeouts relative to the current
   Probe Timeout (PTO).
@@ -466,7 +467,8 @@ active.
 ## Initiating a Connection Close
 
 When the idle timeout expires, an endpoint gracefully shuts down its sending
-side of the underlying transport, without sending any frames.
+side of the underlying transport. The endpoint does not send any QMux frames, though
+it might send messages at lower layers, such as a TLS `close_notify` alert.
 
 Separately, as in QUIC version 1, an endpoint can initiate closing of a QMux
 connection by sending a CONNECTION_CLOSE frame and then gracefully shutting down
@@ -663,8 +665,7 @@ connection alive, to consume processing resources disproportionate to useful
 progress, or to force an endpoint to generate responses. For example, sending
 large numbers of small records, PADDING frames, tiny flow control increments, or
 QX_PING frames can be used for such purposes. Implementations SHOULD monitor for
-such traffic patterns and MAY treat suspicious activity as a connection error of
-type PROTOCOL_VIOLATION.
+such traffic patterns and MAY treat suspicious activity as a connection error.
 
 Unlike QUIC, where each packet is a self-contained unit, QMux records can arrive
 incrementally over the underlying byte stream. Implementations need to consider

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -437,8 +437,7 @@ max_idle_timeout transport parameter.
 
 Endpoints reset the idle timer each time a QMux record is either completely sent
 or completely received. Activity on the underlying transport, such as TCP
-keepalives, does not reset the idle timer. Unlike QUIC version 1, idle timeout
-handling does not rely on acknowledgments; QMux endpoints do not increase their
+keepalives, does not reset the idle timer. QMux endpoints do not increase their
 idle timeouts relative to the current Probe Timeout (PTO).
 
 When idle, a QMux connection may also be torn down by the underlying transport

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -475,7 +475,7 @@ sending side without sending any frames, or after sending a single
 CONNECTION_CLOSE frame.
 
 
-## Handling Resets
+## Handling Resets {#handling-resets}
 
 When the underlying transport becomes unavailable (e.g., due to a TCP reset or a
 TLS fatal alert), the QMux connection is terminated immediately.
@@ -654,6 +654,11 @@ type PROTOCOL_VIOLATION.
 Unlike QUIC, where each packet is a self-contained unit, QMux records can arrive
 incrementally over the underlying byte stream. Implementations need to consider
 resources they might use to hold partially received records.
+
+Unlike QUIC, QMux does not provide protection against premature connection
+termination by unauthenticated on-path entities. An intermediary that can
+disrupt the underlying transport will be able to successfully terminate
+connections; see {{handling-resets}}.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -455,11 +455,10 @@ As a consequence, the idle timeout of QMux is defined as follows:
 * QMux endpoints do not increase their idle timeouts relative to the current
   Probe Timeout (PTO).
 
-When idle, a QMux connection may also be torn down by the underlying transport
-stack or by intermediaries (e.g., Network Address Translation {{?RFC7857}}),
-independent of the negotiated timeout. QX_PING frames can be used to elicit a
-peer response and keep both the QMux connection and the underlying transport
-active.
+While idle, a QMux connection may also be torn down by timers outside of QMux;
+e.g., Network Address Translation {{?RFC7857}}. QX_PING frames can be used to
+elicit a peer response and keep both the QMux connection and the underlying
+transport active.
 
 
 ## Initiating a Connection Close

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -426,41 +426,59 @@ datagrams when they cannot be promptly delivered to the application.
 
 # Connection Termination
 
-A QMux connection can be terminated by a CONNECTION_CLOSE frame, by an idle
-timeout, or by termination of the underlying transport.
-
-
-## Immediate Close
-
-As in QUIC version 1, an endpoint closes the QMux connection by sending a
-CONNECTION_CLOSE frame. Unlike QUIC version 1, there is no draining period; once
-an endpoint sends or receives the CONNECTION_CLOSE frame, all resources
-allocated for the connection are freed and the underlying transport is closed
-immediately.
+A QMux connection can be terminated by an idle timeout, by a CONNECTION_CLOSE
+frame, or by observing a reset of the underlying transport.
 
 
 ## Idle Timeout
 
-As in QUIC version 1, endpoints can negotiate an idle timeout using the
+As in QUIC version 1, endpoints negotiate an idle timeout using the
 max_idle_timeout transport parameter.
 
 Endpoints reset the idle timer when sending or receiving a QMux record. Activity
 on the underlying transport, such as TCP keepalives, does not reset the idle
 timer. Unlike QUIC version 1, idle timeout handling does not rely on
-acknowledgments.
+acknowledgments; QMux endpoints do not increase their idle timeouts relative to
+the current Probe Timeout (PTO).
 
-When no other traffic is available, QX_PING frames can be used to elicit a peer
-response and keep both the QMux connection and the underlying transport active.
+When idle, a QMux connection may also be torn down by the underlying transport
+stack or by intermediaries (e.g., Network Address Translation {{?RFC7857}}),
+independent of the negotiated timeout.
 
-When an endpoint reaches the idle timeout, they can immediately close the
-underlying transport or abandon it without transmitting any signal at their
-discretion.
+QX_PING frames can be used to elicit a peer response and keep both the QMux
+connection and the underlying transport active.
 
 
-## Underlying Transport Termination
+## Initiating a Connection Close
 
-When the underlying transport closes or becomes unavailable (e.g., due to a TCP
-reset or a TLS fatal alert), the QMux connection is also terminated.
+When the idle timeout expires, an endpoint gracefully shuts down its sending
+side of the underlying transport, without sending any frames.
+
+Separately, as in QUIC version 1, an endpoint can initiate closing of a QMux
+connection by sending a CONNECTION_CLOSE frame and then gracefully shuts down
+its sending side of the underlying transport.
+
+In either case, once shutting down the sending side, the endpoint SHOULD wait
+for the peer to gracefully shut down the peer's sending side. The use of
+graceful shutdown mitigates the risk of undelivered records and frames
+becoming lost due to abrupt termination of the underlying transport. While
+waiting for the peer to gracefully shut down, QMux endpoints SHOULD discard any
+data they receive without processing it, similarly to QUIC version 1 endpoints
+discarding packets received during the draining period
+({{Section 10.2.2 of QUIC}}).
+
+
+## Responding to a Connection Close
+
+When receiving a CONNECTION_CLOSE frame or observing the peer shut down the
+peer's sending side, the receiving endpoint SHOULD gracefully shut down its
+sending side, without sending any frames.
+
+
+## Handling Resets
+
+When the underlying transport becomes unavailable (e.g., due to a TCP reset or a
+TLS fatal alert), the QMux connection is terminated immediately.
 
 
 # Using TLS

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -457,8 +457,8 @@ As a consequence, the idle timeout of QMux is defined as follows:
 
 While idle, a QMux connection may also be torn down by timers outside of QMux;
 e.g., Network Address Translation {{?RFC7857}}. QX_PING frames can be used to
-elicit a peer response and keep both the QMux connection and the underlying
-transport active.
+elicit a peer response, which could keep inactivity timers at lower transport
+layers and intermediaries from causing premature connection termination.
 
 
 ## Initiating a Connection Close

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -427,7 +427,7 @@ datagrams when they cannot be promptly delivered to the application.
 # Connection Termination
 
 A QMux connection can be terminated by an idle timeout, by a CONNECTION_CLOSE
-frame, or by observing a reset of the underlying transport.
+frame, or by observing a closure of the underlying transport.
 
 
 ## Idle Timeout

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -455,10 +455,11 @@ As a consequence, the idle timeout of QMux is defined as follows:
 * QMux endpoints do not increase their idle timeouts relative to the current
   Probe Timeout (PTO).
 
-While idle, a QMux connection may also be disrupted by inactivity timers outside of QMux; e.g., a 
-Network Address Translator {{?RFC7857}} that discards its mapping. QX_PING frames can be used to
-elicit a peer response, which could keep inactivity timers at lower transport
-layers and intermediaries from causing premature connection termination.
+While idle, a QMux connection may also be disrupted by inactivity timers outside
+of QMux; e.g., a  Network Address Translator {{?RFC7857}} that discards its
+mapping. QX_PING frames can be used to elicit a peer response, which could keep
+inactivity timers at lower transport layers and intermediaries from causing
+premature connection termination.
 
 
 ## Initiating a Connection Close


### PR DESCRIPTION
This PR expands the connection termination section in the following ways:
* Clarify that a QMux connection can be closed in one of the 3 ways: CONNECTION_CLOSE, idle-timeout, and by an abrupt termination of the underlying transport.
* Point out that QX_PING can be used to increase the idle timeout of the underlying transport too.
* Point out that buffering of partially-received QMux records can be a security concern.

Closes #39. Closes #59.