### PR TITLE
Fix typo: PATH_REPONSE -> PATH_RESPONSE

### DIFF
--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -287,7 +287,7 @@ The full list of prohibited frames is:
 * NEW_CONNECTION_ID
 * RETIRE_CONNECTION_ID
 * PATH_CHALLENGE
-* PATH_REPONSE
+* PATH_RESPONSE
 * HANDSHAKE_DONE
 
 Endpoints MUST NOT send prohibited frames. If an endpoint receives one it MUST


### PR DESCRIPTION
"PATH_REPONSE" is misspelled in the list of prohibited frames, should be "PATH_RESPONSE".