### PR TITLE
Fix hex encoding of protocol magic number

### DIFF
--- a/codepoints.md
+++ b/codepoints.md
@@ -61,6 +61,7 @@ Each row records how its codepoint was selected:
 | QX_PING (request) | 0xTBD | draft-ietf-quic-qmux-00 | Manual Selection |
 | QX_PING (response) | 0x348c67529ef8c7be | draft-ietf-quic-qmux-01 | (consecutive with above) |
 | QX_PING (response) | 0xTBD+1 | draft-ietf-quic-qmux-00 | Manual Selection |
+| QX_TRANSPORT_PARAMETERS | 0x3f514d580d0a0d0a | draft-ietf-quic-qmux-03 | Magic Value |
 | QX_TRANSPORT_PARAMETERS | 0x3f5153300d0a0d0a | draft-ietf-quic-qmux-01 | Magic Value |
 | QX_TRANSPORT_PARAMETERS | 0x3f5153300d0a0d0a | draft-ietf-quic-qmux-00 | Magic Value |
 

--- a/draft-ietf-quic-qmux.md
+++ b/draft-ietf-quic-qmux.md
@@ -325,7 +325,7 @@ QX_TRANSPORT_PARAMETERS frames are formatted as shown in
 
 ~~~
 QX_TRANSPORT_PARAMETERS Frame {
-  Type (i) = 0x3f5153300d0a0d0a,
+  Type (i) = 0x3f514d580d0a0d0a,
   Length (i),
   Transport Parameters (..),
 }
@@ -369,7 +369,7 @@ frame, or if a QX_TRANSPORT_PARAMETERS frame is received other than as the first
 frame, the endpoint MUST close the connection with an error of type
 PROTOCOL_VIOLATION.
 
-The frame type (0x3f5153300d0a0d0a; "\xffQMX\r\n\r\n" on wire) has been chosen
+The frame type (0x3f514d580d0a0d0a; "\xffQMX\r\n\r\n" on wire) has been chosen
 so that it can be used to disambiguate QMux from HTTP/1.1 {{?HTTP1=RFC9112}} and
 HTTP/2.
 
@@ -836,10 +836,10 @@ registry.
 
 | Value | Frame Type Name | Status | Specification |
 |---|---|---|---|
-| 0x3f5153300d0a0d0a | QX_TRANSPORT_PARAMETERS | provisional | {{fig-qx-transport-parameters}} |
+| 0x3f514d580d0a0d0a | QX_TRANSPORT_PARAMETERS | provisional | {{fig-qx-transport-parameters}} |
 | 0x348c67529ef8c7bd - 0x348c67529ef8c7be | QX_PING | provisional | {{fig-qx-ping}} |
 
-The value 0x3f5153300d0a0d0a for QX_TRANSPORT_PARAMETERS was chosen deliberately
+The value 0x3f514d580d0a0d0a for QX_TRANSPORT_PARAMETERS was chosen deliberately
 to function as a protocol magic number see ({{fig-qx-transport-parameters}}).
 
 ## QUIC Transport Parameters
@@ -863,6 +863,11 @@ TODO acknowledge.
 {:numbered="false"}
 
 > **Note to the RFC Editor / Editors:** Delete this section before publication.
+
+## Since draft-ietf-quic-qmux-02
+{:numbered="false"}
+
+- Changed the QX_TRANSPORT_PARAMETERS magic number to 0x3f514d580d0a0d0a so its on-wire bytes spell "\xffQMX\r\n\r\n" as intended and matching the existing description. The previous value 0x3f5153300d0a0d0a encoded "\xffQS0\r\n\r\n", a leftover from the QUIC on Streams naming. This is a breaking wire-format change.
 
 ## Since draft-ietf-quic-qmux-01
 {:numbered="false"}


### PR DESCRIPTION
The intended magic number string was changed to from QS0 to QMX when the spec was renamed (https://github.com/quicwg/qmux/pull/14) and the description shows this correctly, but the hex value was not updated anywhere. The magic number shown still encodes QS0:

```
> echo 3f5153300d0a0d0a | xxd -r -p | cat -v
?QS0^M
^M

```

I've updated this in the spec to the correct hex value of `0x3f514d580d0a0d0a`:

```
> echo 3f514d580d0a0d0a | xxd -r -p | cat -v
?QMX^M
^M

```

This is a bit unfortunate... The incorrect number does seem to be what's currently used in reality (e.g. [here](https://github.com/h2o/quicly/blob/a57824bd85614906b1c74af952a804754c54ac4c/include/quicly/frame.h#L64) and [here](https://github.com/moq-dev/web-transport/blob/c4bd31989749fb2c366d54a751e36161e9a88ebd/rs/qmux/src/proto/frame.rs#L33-L35) - complete with a comment showing the wrong string value) and so obviously this is a breaking wire-format change for everybody.

The alternative I suppose is to revert that magic number rename in the description, and make the `QS0` string the official intended magic number instead, leaving the hex as-is. That's a bit of an awkward wart to have to live with, and now is the easiest time to fix it, but I do understand if it's still too late.